### PR TITLE
Fix TIME in blocks page is shown "2011 years ago"

### DIFF
--- a/frontend/src/app/pipes/moment-from-now.pipe.ts
+++ b/frontend/src/app/pipes/moment-from-now.pipe.ts
@@ -11,8 +11,8 @@ export class MomentFromNowPipe implements PipeTransform {
   transform(value: any, ...args: any[]): any {
     // * 1000 for secondsSinceEpoch
     return moment(
-      new Date(value * 1000).toLocaleString(),
-      'DD/MM/YYYY, HH:mm:ss'
+      new Date(value * 1000).toISOString(),
+      moment.ISO_8601
     ).fromNow();
   }
 }


### PR DESCRIPTION
We should not assume `.toLocaleString()` always returns a specific format
like `DD/MM/YY, HH:mm:ss`. It actually depends on the locale in the
browser.

`.toLocaleString()` might return "2020/11/9 18:44:16". If this is parsed
as `DD/MM/YY, HH:mm:ss`, it will be year=9, month=11, day=2020.  As a
result, relative time become `2011 years ago`.

Use ISO 8601 format in intermediate passing the value instead.

## Former view 
<img width="1473" alt="スクリーンショット 2020-11-10 11 14 59" src="https://user-images.githubusercontent.com/8978782/98620043-d51c8b80-2347-11eb-85c7-37106ef018b8.png">


## Fixed view
<img width="1450" alt="スクリーンショット 2020-11-10 11 29 05" src="https://user-images.githubusercontent.com/8978782/98620111-fc735880-2347-11eb-8e0a-909a5ff4bf3c.png">
