### PR TITLE
Show error message on block list page

### DIFF
--- a/backend/actions/block_detail.js
+++ b/backend/actions/block_detail.js
@@ -18,7 +18,6 @@ app.get('/block/:blockHash', async (req, res) => {
 
   if (!regex.test(urlBlockHash)) {
     logger.error(`Regex Test didn't pass for URL - /block/${urlBlockHash}`);
-
     res.status(400).send('Bad request');
     return;
   }
@@ -40,9 +39,13 @@ app.get('/block/:blockHash', async (req, res) => {
       nextBlock: blockInfo.nextblockhash
     });
   } catch (err) {
-    logger.error(
-      `Error retrieving information for block  - ${urlBlockHash}. Error Message - ${err.message}`
-    );
+    if (err.code === -5) {
+      res.status(404).send('Block Not Found.');
+    } else {
+      logger.error(
+        `Error retrieving information for block  - ${urlBlockHash}. Error Message - ${err.message}`
+      );
+    }
   }
 });
 

--- a/backend/actions/block_detail.js
+++ b/backend/actions/block_detail.js
@@ -18,7 +18,7 @@ app.get('/block/:blockHash', async (req, res) => {
 
   if (!regex.test(urlBlockHash)) {
     logger.error(`Regex Test didn't pass for URL - /block/${urlBlockHash}`);
-    res.status(400).send('Bad request');
+    res.status(400).send('Invalid block hash.');
     return;
   }
 
@@ -40,7 +40,7 @@ app.get('/block/:blockHash', async (req, res) => {
     });
   } catch (err) {
     if (err.code === -5) {
-      res.status(404).send('Block Not Found.');
+      res.status(404).send('Block not found.');
     } else {
       logger.error(
         `Error retrieving information for block  - ${urlBlockHash}. Error Message - ${err.message}`

--- a/frontend/src/app/blocks/blocks.page.html
+++ b/frontend/src/app/blocks/blocks.page.html
@@ -16,8 +16,12 @@
         </ion-col>
       </ion-row>
     </ion-grid>
-
-    <ion-grid class="ion-padding" id="table">
+    <div class="bg-white ion-padding" *ngIf="notFound">
+      <div class="flex">
+        <p id="block-header-text">Not Found</p>
+      </div>
+    </div>
+    <ion-grid class="ion-padding" id="table" *ngIf="!notFound">
       <ion-row id="table-header">
         <ion-col size="2">HEIGHT</ion-col>
         <ion-col size="6">HASH</ion-col>
@@ -47,7 +51,7 @@
       </ion-row>
     </ion-grid>
   </div>
-  <ion-grid>
+  <ion-grid *ngIf="!notFound">
     <ion-row>
       <ion-col style="margin-top: 16px">
         Show

--- a/frontend/src/app/blocks/blocks.page.html
+++ b/frontend/src/app/blocks/blocks.page.html
@@ -17,12 +17,12 @@
         </ion-col>
       </ion-row>
     </ion-grid>
-    <div class="bg-white ion-padding" *ngIf="notFound">
+    <div class="bg-white ion-padding" *ngIf="hasError">
       <div class="flex">
-        <p id="block-header-text">Not Found</p>
+        <p id="block-header-text">{{errorMsg}}</p>
       </div>
     </div>
-    <ion-grid class="ion-padding" id="table" *ngIf="!notFound">
+    <ion-grid class="ion-padding" id="table" *ngIf="!hasError">
       <ion-row id="table-header">
         <ion-col size="2">HEIGHT</ion-col>
         <ion-col size="6">HASH</ion-col>
@@ -52,7 +52,7 @@
       </ion-row>
     </ion-grid>
   </div>
-  <ion-grid *ngIf="!notFound">
+  <ion-grid *ngIf="!hasError">
     <ion-row>
       <ion-col style="margin-top: 16px">
         Show

--- a/frontend/src/app/blocks/blocks.page.html
+++ b/frontend/src/app/blocks/blocks.page.html
@@ -7,6 +7,7 @@
             class="bg-white"
             [(ngModel)]="searchValue"
             placeholder="Search hash"
+            (keyup.enter)="onSearch()"
           ></ion-input>
         </ion-col>
         <ion-col class="ion-no-padding" size="2">

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -78,24 +78,24 @@ export class BlocksPage implements OnInit {
       this.getBlockLists();
     } else {
       this.backendService.searchBlock(this.searchValue).subscribe(
-          data => {
-            const result: any = data || {};
-            this.blocks = [
-              {
-                height: result.height,
-                hash: result.blockHash,
-                time: result.timestamp,
-                size: result.sizeBytes
-              }
-            ];
-            this.pages = 1;
-            this.page = 1;
-            this.bestHeight = 1;
-          },
-          err => {
-            this.hasError = true;
-            this.errorMsg = err.error;
-          }
+        data => {
+          const result: any = data || {};
+          this.blocks = [
+            {
+              height: result.height,
+              hash: result.blockHash,
+              time: result.timestamp,
+              size: result.sizeBytes
+            }
+          ];
+          this.pages = 1;
+          this.page = 1;
+          this.bestHeight = 1;
+        },
+        err => {
+          this.hasError = true;
+          this.errorMsg = err.error;
+        }
       );
     }
   }

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -74,7 +74,7 @@ export class BlocksPage implements OnInit {
 
   onSearch() {
     this.resetError();
-    if (this.searchValue == null || this.searchValue.length == 0) {
+    if (this.searchValue == null || this.searchValue.length === 0) {
       this.getBlockLists();
     } else {
       this.backendService.searchBlock(this.searchValue).subscribe(

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -17,7 +17,8 @@ export class BlocksPage implements OnInit {
   blocks: any = [];
   searchValue: string;
   bestHeight = 0;
-  notFound = false;
+  hasError = false;
+  errorMsg = '';
 
   constructor(
     private httpClient: HttpClient,
@@ -30,7 +31,7 @@ export class BlocksPage implements OnInit {
   }
 
   getBlockLists() {
-    this.notFound = false;
+    this.resetError();
     this.backendService.getBlocks(this.page, this.perPage).subscribe(
       data => {
         const resultData: any = data || {};
@@ -72,7 +73,7 @@ export class BlocksPage implements OnInit {
   }
 
   onSearch() {
-    this.notFound = false;
+    this.resetError();
     this.backendService.searchBlock(this.searchValue).subscribe(
       data => {
         const result: any = data || {};
@@ -89,12 +90,14 @@ export class BlocksPage implements OnInit {
         this.bestHeight = 1;
       },
       err => {
-        if (err.status == 404) {
-          this.notFound = true;
-        } else {
-          console.log(err);
-        }
+        this.hasError = true;
+        this.errorMsg = err.error;
       }
     );
+  }
+
+  resetError() {
+    this.hasError = false;
+    this.errorMsg = '';
   }
 }

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -74,26 +74,30 @@ export class BlocksPage implements OnInit {
 
   onSearch() {
     this.resetError();
-    this.backendService.searchBlock(this.searchValue).subscribe(
-      data => {
-        const result: any = data || {};
-        this.blocks = [
-          {
-            height: result.height,
-            hash: result.blockHash,
-            time: result.timestamp,
-            size: result.sizeBytes
+    if (this.searchValue == null || this.searchValue.length == 0) {
+      this.getBlockLists();
+    } else {
+      this.backendService.searchBlock(this.searchValue).subscribe(
+          data => {
+            const result: any = data || {};
+            this.blocks = [
+              {
+                height: result.height,
+                hash: result.blockHash,
+                time: result.timestamp,
+                size: result.sizeBytes
+              }
+            ];
+            this.pages = 1;
+            this.page = 1;
+            this.bestHeight = 1;
+          },
+          err => {
+            this.hasError = true;
+            this.errorMsg = err.error;
           }
-        ];
-        this.pages = 1;
-        this.page = 1;
-        this.bestHeight = 1;
-      },
-      err => {
-        this.hasError = true;
-        this.errorMsg = err.error;
-      }
-    );
+      );
+    }
   }
 
   resetError() {

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -17,6 +17,7 @@ export class BlocksPage implements OnInit {
   blocks: any = [];
   searchValue: string;
   bestHeight = 0;
+  notFound = false;
 
   constructor(
     private httpClient: HttpClient,
@@ -29,6 +30,7 @@ export class BlocksPage implements OnInit {
   }
 
   getBlockLists() {
+    this.notFound = false;
     this.backendService.getBlocks(this.page, this.perPage).subscribe(
       data => {
         const resultData: any = data || {};
@@ -70,6 +72,7 @@ export class BlocksPage implements OnInit {
   }
 
   onSearch() {
+    this.notFound = false;
     this.backendService.searchBlock(this.searchValue).subscribe(
       data => {
         const result: any = data || {};
@@ -86,7 +89,11 @@ export class BlocksPage implements OnInit {
         this.bestHeight = 1;
       },
       err => {
-        console.log(err);
+        if (err.status == 404) {
+          this.notFound = true;
+        } else {
+          console.log(err);
+        }
       }
     );
   }


### PR DESCRIPTION
This PR changes follow:

* show `Block not found` message, when backend returns 404.
* show `Invalid block hash` message, when backend returns 400.
* If search with empty string, show block list.
* Enter in block hash input field, execute search logic. 