### PR TITLE
Show error message on tx list page

### DIFF
--- a/backend/actions/transaction_detail.js
+++ b/backend/actions/transaction_detail.js
@@ -16,7 +16,7 @@ app.get('/transaction/:txid', async (req, res) => {
   const urlTxid = req.params.txid;
 
   if (!regex.test(urlTxid)) {
-    res.status(400).send('Bad request');
+    res.status(400).send('Invalid txid.');
     return;
   }
 
@@ -46,15 +46,17 @@ app.get('/transaction/:txid/rawData', async (req, res) => {
     logger.error(
       `Regex Test didn't pass for URL - /transaction/${urlTxid}/rawData`
     );
-
-    res.status(400).send('Bad request');
+    res.status(400).send('Invalid txid.');
     return;
   }
 
   try {
     const tx = await electrs.blockchain.transaction.get(urlTxid, false);
-
-    res.json(tx);
+    if (tx === undefined) {
+      res.status(404).send('Tx not found.');
+    } else {
+      res.json(tx);
+    }
   } catch (error) {
     logger.error(
       `Error retrieving rawdata for transaction - ${urlTxid}. Error Message - ${error.message}`
@@ -70,15 +72,17 @@ app.get('/transaction/:txid/get', async (req, res) => {
     logger.error(
       `Regex Test didn't pass for URL - /transaction/${urlTxid}/get`
     );
-
-    res.status(400).send('Bad request');
+    res.status(400).send('Invalid txid.');
     return;
   }
 
   try {
     const tx = await electrs.blockchain.transaction.get(urlTxid, true);
-
-    res.json(tx);
+    if (tx === undefined) {
+      res.status(404).send('Tx not found.');
+    } else {
+      res.json(tx);
+    }
   } catch (error) {
     logger.error(
       `Error calling the method gettransaction for transaction - ${urlTxid}. Error Message - ${error.message}`

--- a/backend/actions/transaction_detail.js
+++ b/backend/actions/transaction_detail.js
@@ -16,22 +16,21 @@ app.get('/transaction/:txid', async (req, res) => {
   const urlTxid = req.params.txid;
 
   if (!regex.test(urlTxid)) {
-    logger.error(`Regex Test didn't pass for URL - /transaction/${urlTxid}`);
-
     res.status(400).send('Bad request');
     return;
   }
 
   try {
     const tx = await electrs.blockchain.transaction.get(urlTxid, true);
-
-    tx.vinRaw = tx.vin.map(async vin => {
-      if (!vin.txid) return {};
-
-      return await electrs.blockchain.transaction.get(vin.txid, true);
-    });
-
-    res.json(tx);
+    if (tx === undefined) {
+      res.status(404).send('Tx not found.');
+    } else {
+      tx.vinRaw = tx.vin.map(async vin => {
+        if (!vin.txid) return {};
+        return await electrs.blockchain.transaction.get(vin.txid, true);
+      });
+      res.json(tx);
+    }
   } catch (error) {
     logger.error(
       `Error retrieving information for transaction - ${urlTxid}. Error Message - ${error.message}`

--- a/backend/test/actions/block_detail.spec.js
+++ b/backend/test/actions/block_detail.spec.js
@@ -95,11 +95,13 @@ describe('GET /block/:blockHash with sinon.stub', function () {
     it('should return 404 response.', function (done) {
       supertest(app)
         .get(
-          '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e5'
+          '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420fe'
         )
         .expect(404)
-        .expect('Content-Type', /json/);
-      done();
+        .expect('Content-Type', /json/)
+        .end(function (err, res) {
+          done();
+        });
     });
   });
 });

--- a/backend/test/actions/transaction_detail.spec.js
+++ b/backend/test/actions/transaction_detail.spec.js
@@ -3,7 +3,6 @@ const assert = require('assert');
 const app = require('../../server');
 require('../../actions/transaction_detail');
 const electrs = require('../../libs/electrs');
-const RpcError = require('bitcoin-core/dist/src/errors/rpc-error').default;
 const sinon = require('sinon');
 
 function isEmpty(obj) {

--- a/frontend/src/app/transaction/transaction.module.ts
+++ b/frontend/src/app/transaction/transaction.module.ts
@@ -16,7 +16,7 @@ import { TransactionRawdataPage } from '../transaction-rawdata/transaction-rawda
     IonicModule,
     TransactionPageRoutingModule
   ],
-  declarations: [TransactionPage, TransactionRawdataPage],
+  declarations: [TransactionRawdataPage, TransactionPage],
   entryComponents: [TransactionRawdataPage]
 })
 export class TransactionPageModule {}

--- a/frontend/src/app/transactions/transactions.page.html
+++ b/frontend/src/app/transactions/transactions.page.html
@@ -7,6 +7,7 @@
             class="bg-white"
             [(ngModel)]="searchValue"
             placeholder="Search txid"
+            (keyup.enter)="onSearch()"
           ></ion-input>
         </ion-col>
         <ion-col size="2">

--- a/frontend/src/app/transactions/transactions.page.html
+++ b/frontend/src/app/transactions/transactions.page.html
@@ -17,8 +17,12 @@
         </ion-col>
       </ion-row>
     </ion-grid>
-
-    <ion-grid class="ion-padding" id="table">
+    <div class="bg-white ion-padding" *ngIf="hasError">
+      <div class="flex">
+        <p id="block-header-text">{{errorMsg}}</p>
+      </div>
+    </div>
+    <ion-grid class="ion-padding" id="table" *ngIf="!hasError">
       <ion-row id="table-header">
         <ion-col size="6">TXID</ion-col>
         <ion-col size="2">TIME</ion-col>
@@ -45,7 +49,7 @@
       </ion-row>
     </ion-grid>
   </div>
-  <ion-grid>
+  <ion-grid *ngIf="!hasError">
     <ion-row>
       <ion-col style="margin-top: 16px">
         Show

--- a/frontend/src/app/transactions/transactions.page.ts
+++ b/frontend/src/app/transactions/transactions.page.ts
@@ -17,6 +17,8 @@ export class TransactionsPage implements OnInit {
   transactions: any = [];
   searchValue: string;
   txCount = 0;
+  hasError = false;
+  errorMsg = '';
 
   constructor(
     private httpClient: HttpClient,
@@ -29,6 +31,7 @@ export class TransactionsPage implements OnInit {
   }
 
   getTransactionLists() {
+    this.resetError();
     this.backendService.getTransactions(this.page, this.perPage).subscribe(
       data => {
         const resultData: any = data || {};
@@ -61,16 +64,27 @@ export class TransactionsPage implements OnInit {
   }
 
   onSearch() {
-    this.backendService.searchTransaction(this.searchValue).subscribe(
-      data => {
-        this.transactions = [data];
-        this.pages = 1;
-        this.page = 1;
-        this.txCount = 1;
-      },
-      err => {
-        console.log(err);
-      }
-    );
+    this.resetError();
+    if (this.searchValue == null || this.searchValue.length === 0) {
+      this.getTransactionLists();
+    } else {
+      this.backendService.searchTransaction(this.searchValue).subscribe(
+        data => {
+          this.transactions = [data];
+          this.pages = 1;
+          this.page = 1;
+          this.txCount = 1;
+        },
+        err => {
+          this.hasError = true;
+          this.errorMsg = err.error;
+        }
+      );
+    }
+  }
+
+  resetError() {
+    this.hasError = false;
+    this.errorMsg = '';
   }
 }


### PR DESCRIPTION
This PR changes follow:

* show Tx not found message, when backend returns 404.
* show Invalid txid message, when backend returns 400.
* If search with empty string, show tx list.
* Enter in txid input field, execute search logic.