### PR TITLE
Add '/api' path all the apis in backend

### DIFF
--- a/backend/actions/address_detail.js
+++ b/backend/actions/address_detail.js
@@ -13,7 +13,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/address/:address', async (req, res) => {
+app.get('/api/address/:address', async (req, res) => {
   // TODO: This API only supports returning 25 records for one request.
   const lastSeenTxid = req.query.lastSeenTxid;
   const address = req.params.address;

--- a/backend/actions/block_detail.js
+++ b/backend/actions/block_detail.js
@@ -12,7 +12,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/block/:blockHash', async (req, res) => {
+app.get('/api/block/:blockHash', async (req, res) => {
   const blockHash = req.params.blockHash;
 
   if (!isHash(blockHash)) {
@@ -51,7 +51,7 @@ app.get('/block/:blockHash', async (req, res) => {
 });
 
 // bitcoin-cli getblock ${blockHash} 0
-app.get('/block/:blockHash/raw', async (req, res) => {
+app.get('/api/block/:blockHash/raw', async (req, res) => {
   const blockHash = req.params.blockHash;
 
   if (!isHash(blockHash)) {
@@ -70,7 +70,7 @@ app.get('/block/:blockHash/raw', async (req, res) => {
   }
 });
 
-app.get('/block/:blockHash/txns', async (req, res) => {
+app.get('/api/block/:blockHash/txns', async (req, res) => {
   const blockHash = req.params.blockHash;
   const perPage = Number(req.query.perPage) || 25;
   const page = Number(req.query.page) || 1;

--- a/backend/actions/block_list.js
+++ b/backend/actions/block_list.js
@@ -11,7 +11,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/blocks', async (req, res) => {
+app.get('/api/blocks', async (req, res) => {
   let perPage = Number(req.query.perPage);
   const page = Number(req.query.page);
 

--- a/backend/actions/color_detail.js
+++ b/backend/actions/color_detail.js
@@ -12,7 +12,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/color/:colorId', async (req, res) => {
+app.get('/api/color/:colorId', async (req, res) => {
   const colorId = req.params.colorId;
   const lastSeenTxid = req.query.lastSeenTxid;
 

--- a/backend/actions/transaction_detail.js
+++ b/backend/actions/transaction_detail.js
@@ -12,7 +12,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.get('/tx/:txid', async (req, res) => {
+app.get('/api/tx/:txid', async (req, res) => {
   const txid = req.params.txid;
 
   if (!isHash(txid)) {
@@ -38,7 +38,7 @@ app.get('/tx/:txid', async (req, res) => {
   }
 });
 
-app.get('/tx/:txid/rawData', async (req, res) => {
+app.get('/api/tx/:txid/rawData', async (req, res) => {
   const txid = req.params.txid;
 
   if (!isHash(txid)) {
@@ -61,7 +61,7 @@ app.get('/tx/:txid/rawData', async (req, res) => {
   }
 });
 
-app.get('/tx/:txid/get', async (req, res) => {
+app.get('/api/tx/:txid/get', async (req, res) => {
   const txid = req.params.txid;
   if (!isHash(txid)) {
     console.error(`Invalid txid(${txid}) -- /tx/${txid}/get`);

--- a/backend/actions/transaction_list.js
+++ b/backend/actions/transaction_list.js
@@ -12,7 +12,7 @@ app.use((req, res, next) => {
 });
 
 //Return a List of transactions
-app.get('/transactions', async (req, res) => {
+app.get('/api/transactions', async (req, res) => {
   let perPage = Number(req.query.perPage);
   const page = Number(req.query.page);
 

--- a/backend/test/actions/address_detail.spec.js
+++ b/backend/test/actions/address_detail.spec.js
@@ -6,7 +6,7 @@ const rest = require('../../libs/rest');
 const sinon = require('sinon');
 const fixtures = require('../fixtures/txs.json');
 
-describe('GET /address', () => {
+describe('GET /api/address', () => {
   beforeEach(() => {
     sinon
       .stub(rest.address, 'stats')
@@ -35,7 +35,7 @@ describe('GET /address', () => {
     });
     it('should return balances and txs', done => {
       supertest(app)
-        .get('/address/12FmjcAHuen1gptnZoSZ7MLWmNhZny6GmP')
+        .get('/api/address/12FmjcAHuen1gptnZoSZ7MLWmNhZny6GmP')
         .query({})
         .expect(200)
         .expect('Content-Type', /json/)
@@ -73,7 +73,7 @@ describe('GET /address', () => {
     });
     it('should return balances and txs', done => {
       supertest(app)
-        .get('/address/12FmjcAHuen1gptnZoSZ7MLWmNhZny6GmP')
+        .get('/api/address/12FmjcAHuen1gptnZoSZ7MLWmNhZny6GmP')
         .query({
           lastSeenTxid:
             'b9112788b9509306bedd77142f24e3a647190ecb5351a22e71eb203dec0f28fc'

--- a/backend/test/actions/block_detail.spec.js
+++ b/backend/test/actions/block_detail.spec.js
@@ -5,7 +5,7 @@ require('../../actions/block_detail');
 const rest = require('../../libs/rest');
 const sinon = require('sinon');
 
-describe('GET /block/:blockHash', function () {
+describe('GET /api/block/:blockHash', function () {
   beforeEach(() => {
     sinon
       .stub(rest.block, 'get')
@@ -61,7 +61,7 @@ describe('GET /block/:blockHash', function () {
     it('should return block information.', function (done) {
       supertest(app)
         .get(
-          '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6'
+          '/api/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6'
         )
         .expect(200)
         .expect('Content-Type', /json/)
@@ -107,7 +107,7 @@ describe('GET /block/:blockHash', function () {
     it('should return 404 response.', function (done) {
       supertest(app)
         .get(
-          '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420fe'
+          '/api/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420fe'
         )
         .expect(404)
         .then(res => {
@@ -118,7 +118,7 @@ describe('GET /block/:blockHash', function () {
   });
 });
 
-describe('GET /block/:blockHash/raw', function () {
+describe('GET /api/block/:blockHash/raw', function () {
   beforeEach(() => {
     sinon
       .stub(rest.block, 'raw')
@@ -134,10 +134,10 @@ describe('GET /block/:blockHash/raw', function () {
     sinon.restore();
   });
 
-  it('/block/:blockHash/raw', function (done) {
+  it('/api/block/:blockHash/raw', function (done) {
     supertest(app)
       .get(
-        '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6/raw'
+        '/api/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6/raw'
       )
       .expect(200)
       .expect('Content-Type', /json/)
@@ -153,7 +153,7 @@ describe('GET /block/:blockHash/raw', function () {
   });
 });
 
-describe('GET /block/:blockHash/txns', function () {
+describe('GET /api/block/:blockHash/txns', function () {
   beforeEach(() => {
     sinon
       .stub(rest.block, 'txs')
@@ -201,7 +201,7 @@ describe('GET /block/:blockHash/txns', function () {
   it('/block/:blockHash/txns', function (done) {
     supertest(app)
       .get(
-        '/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6/txns'
+        '/api/block/5c6fd3ae9a05a6db255525bd6b1e5e4cb9cfbda876ee39cc809129a9ade420e6/txns'
       )
       .expect(200)
       .expect('Content-Type', /json/)

--- a/backend/test/actions/block_list.spec.js
+++ b/backend/test/actions/block_list.spec.js
@@ -7,7 +7,7 @@ const fixtures = require('../fixtures/blocks.json');
 
 const sinon = require('sinon');
 
-describe('GET /blocks and then call individual block using /block/:blockHash', () => {
+describe('GET /api/blocks and then call individual block using /block/:blockHash', () => {
   beforeEach(() => {
     sinon.stub(rest.block.tip, 'height').resolves(30);
     sinon
@@ -22,9 +22,9 @@ describe('GET /blocks and then call individual block using /block/:blockHash', (
     sinon.restore();
   });
 
-  it('/blocks', done => {
+  it('/api/blocks', done => {
     supertest(app)
-      .get('/blocks')
+      .get('/api/blocks')
       .query({ perPage: '15', page: 1 })
       .expect(200)
       .expect('Content-Type', /json/)

--- a/backend/test/actions/transaction_detail.spec.js
+++ b/backend/test/actions/transaction_detail.spec.js
@@ -5,7 +5,7 @@ require('../../actions/transaction_detail');
 const rest = require('../../libs/rest');
 const sinon = require('sinon');
 
-describe('GET /tx/:txid', () => {
+describe('GET /api/tx/:txid', () => {
   beforeEach(() => {
     sinon
       .stub(rest.transaction, 'get')
@@ -63,7 +63,7 @@ describe('GET /tx/:txid', () => {
     it('should return transaction information', done => {
       supertest(app)
         .get(
-          '/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8'
+          '/api/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8'
         )
         .expect(200)
         .expect('Content-Type', /json/)
@@ -114,7 +114,7 @@ describe('GET /tx/:txid', () => {
     it('should return 404 response.', done => {
       supertest(app)
         .get(
-          '/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c3'
+          '/api/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c3'
         )
         .expect(404)
         .then(res => {
@@ -125,7 +125,7 @@ describe('GET /tx/:txid', () => {
   });
 });
 
-describe('GET /tx/:txid/rawData', () => {
+describe('GET /api/tx/:txid/rawData', () => {
   beforeEach(() => {
     sinon
       .stub(rest.transaction, 'raw')
@@ -141,10 +141,10 @@ describe('GET /tx/:txid/rawData', () => {
     sinon.restore();
   });
 
-  it('/tx/:txid/rawData', done => {
+  it('/api/tx/:txid/rawData', done => {
     supertest(app)
       .get(
-        '/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8/rawData'
+        '/api/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8/rawData'
       )
       .expect(200)
       .expect('Content-Type', /json/)
@@ -164,7 +164,7 @@ describe('GET /tx/:txid/rawData', () => {
   });
 });
 
-describe('GET /tx/:txid/get', () => {
+describe('GET /api/tx/:txid/get', () => {
   beforeEach(() => {
     sinon
       .stub(rest.transaction, 'get')
@@ -212,10 +212,10 @@ describe('GET /tx/:txid/get', () => {
     sinon.restore();
   });
 
-  it('/tx/:txid/get', done => {
+  it('/api/tx/:txid/get', done => {
     supertest(app)
       .get(
-        '/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8/get'
+        '/api/tx/a82d9931eece4f2504691810db4a11d406a6eb2345b739fc35bb4f993d85e7c8/get'
       )
       .expect(200)
       .expect('Content-Type', /json/)

--- a/backend/test/actions/transaction_list.spec.js
+++ b/backend/test/actions/transaction_list.spec.js
@@ -5,7 +5,7 @@ require('../../actions/transaction_list');
 const rest = require('../../libs/rest');
 const sinon = require('sinon');
 
-describe('GET /transactions', () => {
+describe('GET /api/transactions', () => {
   beforeEach(() => {
     sinon
       .stub(rest.mempool, 'list')
@@ -31,7 +31,7 @@ describe('GET /transactions', () => {
 
   it('should return recent transactions', done => {
     supertest(app)
-      .get('/transactions')
+      .get('/api/transactions')
       .query({ perPage: '25', page: 1 })
       .expect(200)
       .expect('Content-Type', /json/)

--- a/frontend/src/app/backend.service.ts
+++ b/frontend/src/app/backend.service.ts
@@ -14,7 +14,7 @@ export class BackendService {
   }
 
   getBlocks(page: number, perPage: number): Observable<any> {
-    return this.http.get(`${this.backendUrl}/blocks`, {
+    return this.http.get(`${this.backendUrl}/api/blocks`, {
       params: new HttpParams({
         fromObject: { page: page.toString(), perPage: perPage.toString() }
       })
@@ -22,15 +22,15 @@ export class BackendService {
   }
 
   searchBlock(query: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/block/${query}`);
+    return this.http.get(`${this.backendUrl}/api/block/${query}`);
   }
 
   getBlock(blockHash: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/block/${blockHash}`);
+    return this.http.get(`${this.backendUrl}/api/block/${blockHash}`);
   }
 
   getRawBlock(blockHash: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/block/${blockHash}/raw`);
+    return this.http.get(`${this.backendUrl}/api/block/${blockHash}/raw`);
   }
 
   getBlockTransactions(
@@ -38,7 +38,7 @@ export class BackendService {
     page: number,
     perPage: number
   ): Observable<any> {
-    return this.http.get(`${this.backendUrl}/block/${blockHash}/txns`, {
+    return this.http.get(`${this.backendUrl}/api/block/${blockHash}/txns`, {
       params: new HttpParams({
         fromObject: { page: page.toString(), perPage: perPage.toString() }
       })
@@ -46,7 +46,7 @@ export class BackendService {
   }
 
   getTransactions(page: number, perPage: number): Observable<any> {
-    return this.http.get(`${this.backendUrl}/transactions`, {
+    return this.http.get(`${this.backendUrl}/api/transactions`, {
       params: new HttpParams({
         fromObject: { page: page.toString(), perPage: perPage.toString() }
       })
@@ -54,15 +54,15 @@ export class BackendService {
   }
 
   getTransaction(txId: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/tx/${txId}`);
+    return this.http.get(`${this.backendUrl}/api/tx/${txId}`);
   }
 
   getRawTransaction(txId: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/tx/${txId}/rawData`);
+    return this.http.get(`${this.backendUrl}/api/tx/${txId}/rawData`);
   }
 
   getAddressInfo(address: string, lastSeenTxid?: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/address/${address}`, {
+    return this.http.get(`${this.backendUrl}/api/address/${address}`, {
       params: new HttpParams({
         fromObject: {
           lastSeenTxid: (lastSeenTxid || '').toString()
@@ -72,11 +72,11 @@ export class BackendService {
   }
 
   searchTransaction(query: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/tx/${query}/get`);
+    return this.http.get(`${this.backendUrl}/api/tx/${query}/get`);
   }
 
   getColor(colorId: string, lastSeenTxid?: string): Observable<any> {
-    return this.http.get(`${this.backendUrl}/color/${colorId}`, {
+    return this.http.get(`${this.backendUrl}/api/color/${colorId}`, {
       params: new HttpParams({
         fromObject: {
           lastSeenTxid: (lastSeenTxid || '').toString()


### PR DESCRIPTION
This is for deployment.

To recognize to be requests for backend in a load balancer. 
Some load balancers like ALB  are able to recoginize path to switch to forward the requests to targets.