### PR TITLE
Feature/page for block height

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -14,6 +14,11 @@ const routes: Routes = [
       import('./blocks/blocks.module').then(m => m.BlocksPageModule)
   },
   {
+    path: 'block/height/:height',
+    loadChildren: () =>
+      import('./block/block.module').then(m => m.BlockPageModule)
+  },
+  {
     path: 'block/:hash',
     loadChildren: () =>
       import('./block/block.module').then(m => m.BlockPageModule)

--- a/frontend/src/app/backend.service.ts
+++ b/frontend/src/app/backend.service.ts
@@ -30,6 +30,10 @@ export class BackendService {
     return this.http.get(`${this.backendUrl}/api/block/${blockHash}`);
   }
 
+  getBlockByHeight(height: number): Observable<any> {
+    return this.http.get(`${this.backendUrl}/api/block/height/${height}`);
+  }
+
   getRawBlock(blockHash: string): Observable<any> {
     return this.http.get(`${this.backendUrl}/api/block/${blockHash}/raw`);
   }

--- a/frontend/src/app/block/block.page.ts
+++ b/frontend/src/app/block/block.page.ts
@@ -13,6 +13,7 @@ import { AppConst } from '../app.const';
 })
 export class BlockPage implements OnInit {
   blockHash: string;
+  height: number;
   block: any = {};
   blockTxns: any = {};
   openTxns = false;
@@ -37,13 +38,39 @@ export class BlockPage implements OnInit {
 
   ngOnInit() {
     this.blockHash = this.activatedRoute.snapshot.paramMap.get('hash');
+    this.height = Number(this.activatedRoute.snapshot.paramMap.get('height'));
     this.getBlockInfo();
   }
 
   getBlockInfo() {
+    if (this.blockHash != null) {
+      this.getBlockInfoByHash();
+    } else if (this.height != null) {
+      this.getBlockInfoByHeight();
+    }
+  }
+
+  getBlockInfoByHash() {
     this.backendService.getBlock(this.blockHash).subscribe(
       data => {
         this.block = data || {};
+        this.calculatePagination();
+      },
+      err => {
+        console.log(err);
+        this.hasError = true;
+        this.statusCode = err.status;
+        this.statusMsg = err.statusText;
+        this.detailMsg = err.error;
+      }
+    );
+  }
+
+  getBlockInfoByHeight() {
+    this.backendService.getBlockByHeight(this.height).subscribe(
+      data => {
+        this.block = data || {};
+        this.blockHash = this.block.blockHash;
         this.calculatePagination();
       },
       err => {

--- a/frontend/src/app/blocks/blocks.page.spec.ts
+++ b/frontend/src/app/blocks/blocks.page.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { BlocksPage } from './blocks.page';
+import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgxPaginationModule } from 'ngx-pagination';
 
@@ -15,7 +16,8 @@ describe('BlocksPage', () => {
       imports: [
         IonicModule.forRoot(),
         HttpClientTestingModule,
-        NgxPaginationModule
+        NgxPaginationModule,
+        RouterTestingModule
       ]
     }).compileComponents();
 

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -68,6 +68,9 @@ export class BlocksPage implements OnInit {
 
   onPageChange(pageNumber: number) {
     this.page = pageNumber;
+    this.navCtrl.navigateForward('/blocks', {
+      queryParams: { page: this.page }
+    });
     this.getBlockLists();
   }
 

--- a/frontend/src/app/blocks/blocks.page.ts
+++ b/frontend/src/app/blocks/blocks.page.ts
@@ -4,6 +4,7 @@ import { NavController } from '@ionic/angular';
 
 import { BackendService } from '../backend.service';
 import { AppConst } from '../app.const';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-blocks',
@@ -26,10 +27,14 @@ export class BlocksPage implements OnInit {
   constructor(
     private httpClient: HttpClient,
     private navCtrl: NavController,
-    private backendService: BackendService
+    private backendService: BackendService,
+    private activatedRoute: ActivatedRoute
   ) {}
 
   ngOnInit() {
+    this.activatedRoute.queryParamMap.subscribe(params => {
+      this.page = Math.max(Number(params.get('page')), 1);
+    });
     this.getBlockLists();
   }
 


### PR DESCRIPTION
resolve #91 

- Add new routing to page for block information with a specified height
    - `GET /block/height/:height`
- Add query parameter `page` to block list page
    -  `GET /blocks?page=:page`