### PR TITLE
fix: Chrome展開不具合を避けるためNodeを24.15.0に固定

### DIFF
--- a/.github/workflows/ci_on_push_pull_request.yml
+++ b/.github/workflows/ci_on_push_pull_request.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        # Node 24.16.0 は extract-zip の不具合で Puppeteer の Chrome 展開に失敗するため 24.15.0 に固定する (puppeteer/puppeteer#15071)
+        node-version: [22.x, 24.15.0]
     env:
       TZ: "Asia/Tokyo"
     steps:


### PR DESCRIPTION
## **概要**
resolves #300 

フロントエンドCIのKarmaテストが `Cannot start ChromeHeadless` で失敗する問題を解消する。
Node 24.16.0 のリグレッションによりPuppeteerのChrome展開が不完全になることが原因であり、Nodeバージョンを固定して回避する。

Node 24.16.0 上では `extract-zip` による展開が途中で破綻し、`chrome` 実行ファイルが書き出されないまま `install` が成功扱い(exit=0)となる。
結果としてKarmaが `~/.cache/puppeteer/.../chrome-linux64/chrome` を見つけられず起動失敗していた。

## **変更内容**
- `.github/workflows/ci_on_push_pull_request.yml` のテストマトリクスを変更。
  - `node-version: [22.x, 24.x]` → `[22.x, 24.15.0]`
  - 理由を示すコメントを併記（puppeteer/puppeteer#15071 参照）。

## **影響範囲**
- GitHub Actions のCIワークフロー（`CI on Push and PullRequest`）のみ。
- AWSリソース・本番/testnet環境への影響は無い。
- アプリケーションコードの変更は無い。

## **検証手順**
1. 本PRのCIが `22.x` / `24.15.0` 両方で成功することを確認する。
2. Frontendステップで `npm run test ... --browsers=ChromeHeadlessCI` が成功することを確認する。

## **関連Issue**
- https://github.com/puppeteer/puppeteer/issues/15071 
- https://github.com/puppeteer/puppeteer/issues/14957

## **備考**
- 本対応は暫定回避である。Puppeteer/Node側で修正版が出たら `24.x` に戻すことが望ましい
